### PR TITLE
Feature/custom logging target

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ region               = "us-east-1"
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | allowed\_account\_ids | Account IDs that are allowed to access the bucket/KMS key | list(string) | `[]` | no |
-| bucket | Name of bucket to create \(do not provide if using `remote\_bucket`\) | string | `""` | no |
+| bucket | Name of bucket to create \(do not provide if using `remote_bucket`\) | string | `""` | no |
 | kms\_key\_id | ARN for KMS key for all encryption operations. | string | `""` | no |
 | region | Region bucket will be created in | string | n/a | yes |
 | remote\_bucket | If specified, the remote bucket will be used for the backend. A new bucket will not be created | string | `""` | no |

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ region               = "us-east-1"
 | allowed\_account\_ids | Account IDs that are allowed to access the bucket/KMS key | list(string) | `[]` | no |
 | bucket | Name of bucket to create \(do not provide if using `remote_bucket`\) | string | `""` | no |
 | kms\_key\_id | ARN for KMS key for all encryption operations. | string | `""` | no |
+| logging\_target\_bucket | The name of the bucket that will receive the log objects | string | `var.bucket` | no |
+| logging\_target\_prefix | A key prefix for log objects | string | `"TFStateLogs/"` | no |
 | region | Region bucket will be created in | string | n/a | yes |
 | remote\_bucket | If specified, the remote bucket will be used for the backend. A new bucket will not be created | string | `""` | no |
 | table | Name of Dynamo Table to create | string | `"tf-locktable"` | no |

--- a/main.tf
+++ b/main.tf
@@ -49,8 +49,8 @@ resource "aws_s3_bucket" "this" {
   }
 
   logging {
-    target_bucket = var.bucket
-    target_prefix = "TFStateLogs/"
+    target_bucket = var.logging_target_bucket != "" ? var.logging_target_bucket : var.bucket
+    target_prefix = var.logging_target_prefix
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ resource "aws_s3_bucket" "this" {
   }
 
   logging {
-    target_bucket = var.logging_target_bucket != "" ? var.logging_target_bucket : var.bucket
+    target_bucket = coalesce(var.logging_target_bucket, var.bucket)
     target_prefix = var.logging_target_prefix
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,18 @@ variable "kms_key_id" {
   type        = string
 }
 
+variable "logging_target_bucket" {
+  default     = ""
+  description = "The name of the bucket that will receive the log objects"
+  type        = string
+}
+
+variable "logging_target_prefix" {
+  default     = "TFStateLogs/"
+  description = "A key prefix for log objects"
+  type        = string
+}
+
 variable "region" {
   description = "Region bucket will be created in"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "kms_key_id" {
 }
 
 variable "logging_target_bucket" {
-  default     = ""
+  default     = null
   description = "The name of the bucket that will receive the log objects"
   type        = string
 }


### PR DESCRIPTION
AWS does not recommend saving S3 access logs to the same bucket as this creates an infinite loop of logging (each log file saved generates an additional log file about itself being created, ad infinitum). See: https://aws.amazon.com/premiumsupport/knowledge-center/s3-server-access-logs-same-bucket/

I've created a patch that allows you to customize the target bucket for saving S3 access logs of the TF state bucket to a different, pre-existing S3 bucket.  I've written it in such a way that's it's backwards compatible (i.e. it will be configured to save to itself with the same key as previously if the new variables aren't provided).  I've tested it with both default settings (old behaviour) and overriding with a custom bucket.

Let me know if you have any questions. Thanks!